### PR TITLE
Remove a tracking piece.

### DIFF
--- a/lwirv-2018-09-21.md
+++ b/lwirv-2018-09-21.md
@@ -15,7 +15,7 @@ February.  Last year our talk went great and a room was suggested, so I
 anticipate this will be accepted.  We should officially hear back about
 the submission by the end of the month.  Thanks to Karsten for
 [starting the thread that got the discussion
-started](https://groups.google.com/a/groups.riscv.org/forum/?utm_medium=email&utm_source=footer#!msg/sw-dev/fndi2PKkDGU/ehOGUCQrFQAJ).
+started](https://groups.google.com/a/groups.riscv.org/forum/#!msg/sw-dev/fndi2PKkDGU/ehOGUCQrFQAJ).
 
 ## RISC-V Buildroot Patch Submission
 


### PR DESCRIPTION
Noticed the Google Groups url still has the marketing/tracking tags embedded.  This PR just strips them from it as they provide negative use for the target audience.